### PR TITLE
#16-문자인증 구현

### DIFF
--- a/src/main/java/com/lifeManager/opalyouth/common/config/SecurityConfig.java
+++ b/src/main/java/com/lifeManager/opalyouth/common/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
 
         // authorization
         http.authorizeRequests()
-                .antMatchers("/login/**", "/signup", "/", "/stomp/**", "/chat/**").permitAll() // todo : 프론트앤드 구현 완료 시 /chat/**는 삭제
+                .antMatchers("/login/**", "/signup", "/", "/stomp/**", "/chat/**", "/message/certify").permitAll() // todo : 프론트앤드 구현 완료 시 /chat/**는 삭제
                 .anyRequest().hasRole("USER");
     }
 

--- a/src/main/java/com/lifeManager/opalyouth/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/lifeManager/opalyouth/common/response/BaseResponseStatus.java
@@ -34,6 +34,7 @@ public enum BaseResponseStatus {
      * Server Error - 5xx 에러
      */
     IMAGE_INSERT_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "이미지 저장에 실패하였습니다."),
+    SEND_MESSAGE_FAILURE(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "인증 코드 전송에 실패하였습니다."),
     DATABASE_INSERT_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "데이터베이스 저장에 실패하였습니다."),
     INIT_TODAY_FRIENDS_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "오늘의 친구 추천에 실패하였습니다."),
     INTERNAL_SERVER_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "알 수 없는 에러가 발생하였습니다."),

--- a/src/main/java/com/lifeManager/opalyouth/controller/MemberController.java
+++ b/src/main/java/com/lifeManager/opalyouth/controller/MemberController.java
@@ -2,29 +2,32 @@ package com.lifeManager.opalyouth.controller;
 
 import com.lifeManager.opalyouth.common.exception.BaseException;
 import com.lifeManager.opalyouth.common.response.BaseResponse;
+import com.lifeManager.opalyouth.common.response.BaseResponseStatus;
 import com.lifeManager.opalyouth.dto.friends.FriendsPageResponse;
 import com.lifeManager.opalyouth.dto.member.request.*;
 import com.lifeManager.opalyouth.dto.member.response.BlockedMemberResponse;
 import com.lifeManager.opalyouth.dto.member.response.*;
 import com.lifeManager.opalyouth.dto.friends.LikeFriendsPageResponse;
+import com.lifeManager.opalyouth.dto.messageCertify.MessageCertifyRequest;
+import com.lifeManager.opalyouth.dto.messageCertify.MessageCertifyResponse;
+import com.lifeManager.opalyouth.utils.MessageCertifyUtil;
 import org.springframework.validation.BindingResult;
 
 import com.lifeManager.opalyouth.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.security.Principal;
 import java.util.List;
 
-import javax.validation.Valid;
 
 
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
+    private final MessageCertifyUtil messageCertifyUtil;
 
     @PostMapping("/signup")
     public BaseResponse<String> signup(@Valid @RequestBody MemberSignupRequest memberSignupRequest, BindingResult result) {
@@ -38,6 +41,17 @@ public class MemberController {
             return new BaseResponse<>("회원가입에 성공하였습니다.");
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    @PostMapping("/message/certify")
+    public BaseResponse<MessageCertifyResponse> messageCertificate(@RequestBody MessageCertifyRequest messageCertifyRequest) {
+        try {
+            MessageCertifyResponse messageCertifyResponse = messageCertifyUtil.sendSms(messageCertifyRequest);
+            return new BaseResponse<>(messageCertifyResponse);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new BaseResponse<>(new BaseException(BaseResponseStatus.SEND_MESSAGE_FAILURE).getStatus());
         }
     }
 

--- a/src/main/java/com/lifeManager/opalyouth/dto/messageCertify/MessageCertifyRequest.java
+++ b/src/main/java/com/lifeManager/opalyouth/dto/messageCertify/MessageCertifyRequest.java
@@ -1,0 +1,10 @@
+package com.lifeManager.opalyouth.dto.messageCertify;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MessageCertifyRequest {
+    private String phoneNumber;
+}

--- a/src/main/java/com/lifeManager/opalyouth/dto/messageCertify/MessageCertifyResponse.java
+++ b/src/main/java/com/lifeManager/opalyouth/dto/messageCertify/MessageCertifyResponse.java
@@ -1,0 +1,32 @@
+package com.lifeManager.opalyouth.dto.messageCertify;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MessageCertifyResponse {
+    private String certifyCode;
+    private String requestId;
+    private String requestTime;
+    private String statusCode;
+    private String statusName;
+
+    public MessageCertifyResponse(String certifyCode, String requestId, String requestTime, String statusCode, String statusName) {
+        this.certifyCode = certifyCode;
+        this.requestId = requestId;
+        this.requestTime = requestTime;
+        this.statusCode = statusCode;
+        this.statusName = statusName;
+    }
+
+    public static MessageCertifyResponse naverResponseToCertifyResponse(MessageNaverResponse messageNaverResponse, String certifyCode) {
+        return new MessageCertifyResponse(
+                certifyCode,
+                messageNaverResponse.getRequestId(),
+                messageNaverResponse.getRequestTime(),
+                messageNaverResponse.getStatusCode(),
+                messageNaverResponse.getStatusName()
+        );
+    }
+}

--- a/src/main/java/com/lifeManager/opalyouth/dto/messageCertify/MessageNaverRequest.java
+++ b/src/main/java/com/lifeManager/opalyouth/dto/messageCertify/MessageNaverRequest.java
@@ -1,0 +1,49 @@
+package com.lifeManager.opalyouth.dto.messageCertify;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MessageNaverRequest {
+    private String type;
+    private String contentType;
+    private String countryCode;
+    private String from;
+    private String content;
+    private List<MessagesDto> messages;
+
+    @Builder
+    public MessageNaverRequest(
+            String type,
+            String contentType,
+            String countryCode,
+            String from,
+            String content,
+            List<MessagesDto> messages
+    ) {
+        this.type = type;
+        this.contentType = contentType;
+        this.countryCode = countryCode;
+        this.from = from;
+        this.content = content;
+        this.messages = messages;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class MessagesDto {
+        private String to;
+
+        @Builder
+        public MessagesDto(String to) {
+            this.to = to;
+        }
+    }
+}

--- a/src/main/java/com/lifeManager/opalyouth/dto/messageCertify/MessageNaverResponse.java
+++ b/src/main/java/com/lifeManager/opalyouth/dto/messageCertify/MessageNaverResponse.java
@@ -1,0 +1,13 @@
+package com.lifeManager.opalyouth.dto.messageCertify;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MessageNaverResponse {
+    private String requestId;
+    private String requestTime;
+    private String statusCode;
+    private String statusName;
+}

--- a/src/main/java/com/lifeManager/opalyouth/service/FriendsService.java
+++ b/src/main/java/com/lifeManager/opalyouth/service/FriendsService.java
@@ -5,7 +5,6 @@ import com.lifeManager.opalyouth.common.exception.BaseException;
 import com.lifeManager.opalyouth.common.response.BaseResponseStatus;
 import com.lifeManager.opalyouth.dto.friends.BriefFriendsInfoResponse;
 import com.lifeManager.opalyouth.dto.friends.DetailFriendsInfoResponse;
-import com.lifeManager.opalyouth.dto.member.request.FriendsConditionRequest;
 import com.lifeManager.opalyouth.entity.Details;
 import com.lifeManager.opalyouth.entity.Member;
 import com.lifeManager.opalyouth.entity.TodaysFriends;

--- a/src/main/java/com/lifeManager/opalyouth/utils/MessageCertifyUtil.java
+++ b/src/main/java/com/lifeManager/opalyouth/utils/MessageCertifyUtil.java
@@ -1,0 +1,145 @@
+package com.lifeManager.opalyouth.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lifeManager.opalyouth.dto.messageCertify.MessageCertifyRequest;
+import com.lifeManager.opalyouth.dto.messageCertify.MessageCertifyResponse;
+import com.lifeManager.opalyouth.dto.messageCertify.MessageNaverRequest;
+import com.lifeManager.opalyouth.dto.messageCertify.MessageNaverResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+@Slf4j
+@Component
+public class MessageCertifyUtil {
+
+    @Value("${naver-cloud-sms.access-key}")
+    private String accessKey;
+
+    @Value("${naver-cloud-sms.secret-key}")
+    private String secretKey;
+
+    @Value("${naver-cloud-sms.service-id}")
+    private String serviceId;
+
+    @Value("${naver-cloud-sms.sender-phone}")
+    private String senderPhoneNum;
+
+
+    public MessageCertifyResponse sendSms(MessageCertifyRequest messageCertifyRequest) throws JsonProcessingException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+        String time = Long.toString(System.currentTimeMillis());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-ncp-apigw-timestamp", time);
+        headers.set("x-ncp-iam-access-key", accessKey);
+        headers.set("x-ncp-apigw-signature-v2", makeSignature(time)); // API Gateway Signature
+
+        String code = createSmsCode();
+
+        List<MessageNaverRequest.MessagesDto> messages = new ArrayList<>();
+        messages.add(new MessageNaverRequest.MessagesDto(messageCertifyRequest.getPhoneNumber().replaceAll("-", "")));
+
+        MessageNaverRequest request = MessageNaverRequest.builder()
+                .type("SMS")
+                .contentType("COMM")
+                .from(senderPhoneNum)
+                .countryCode("82")
+                .content("[오팔청춘]" + "\n" +"인증번호 [" + code + "]를 입력해주세요.")
+                .messages(messages)
+                .build();
+
+        log.info("request type : {}", request.getType());
+        log.info("request contentType : {}", request.getContentType());
+        log.info("request from : {}", request.getFrom());
+        log.info("request countryCode : {}", request.getCountryCode());
+        log.info("request content : {}", request.getContent());
+        log.info("request messages : {}", request.getMessages());
+
+        // MessageNaverRequest Object를 Json으로 변환
+        ObjectMapper objectMapper = new ObjectMapper();
+        String body = objectMapper.writeValueAsString(request);
+
+        // jsonBody와 헤더 조립
+        HttpEntity<String> http = new HttpEntity<>(body, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        URI uri = UriComponentsBuilder.fromHttpUrl("https://sens.apigw.ntruss.com/sms/v2/services/"+ serviceId +"/messages")
+                .build().toUri();
+
+        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+
+        MessageNaverResponse naverResponse = restTemplate.postForObject(uri, http, MessageNaverResponse.class);
+
+        MessageCertifyResponse messageCertifyResponse = MessageCertifyResponse.naverResponseToCertifyResponse(naverResponse, code);
+        return messageCertifyResponse;
+    }
+
+    /**
+     * 인증 코드 생성
+     * @return
+     */
+    public String createSmsCode() {
+        StringBuffer code = new StringBuffer();
+        Random random = new Random();
+
+        for (int i = 0; i < 5; i++) { // 인증코드 5자리
+            code.append((random.nextInt(10)));
+        }
+        return code.toString();
+    }
+
+    /**
+     * https://api.ncloud-docs.com/docs/common-ncpapi
+     * 위 API 명세서에 따라 작성한 makeSignature 메서드
+     * @param time
+     * @return
+     * @throws NoSuchAlgorithmException
+     * @throws UnsupportedEncodingException
+     * @throws InvalidKeyException
+     */
+    public String makeSignature(String time) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+        String space = " ";
+        String newLine = "\n";
+        String method = "POST";
+        String url = "/sms/v2/services/"+ this.serviceId+"/messages";
+        String accessKey = this.accessKey;
+        String secretKey = this.secretKey;
+
+        String message = new StringBuilder()
+                .append(method)
+                .append(space)
+                .append(url)
+                .append(newLine)
+                .append(time)
+                .append(newLine)
+                .append(accessKey)
+                .toString();
+
+        SecretKeySpec signingKey = new SecretKeySpec(secretKey.getBytes("UTF-8"), "HmacSHA256");
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(signingKey);
+
+        byte[] rawHmac = mac.doFinal(message.getBytes("UTF-8"));
+        String encodeBase64String = Base64.encodeBase64String(rawHmac);
+
+        return encodeBase64String;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,5 +83,11 @@ cloud:
         endpoint: https://kr.object.ncloudstorage.com
         bucket: ${NAVER_CLOUD_BUCKET_NAME}
 
+naver-cloud-sms:
+  access-key: ${NAVER_CLOUD_ACCESS_KEY}
+  secret-key: ${NAVER_CLOUD_SECRET_KEY}
+  service-id: ${NAVER_SENS_SERVICE_ID}
+  sender-phone: ${NAVER_SENS_PHONE_NUMBER}
+
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
- SecurityConfig : 문자인증은 인증, 인가가 필요 없으므로 permitAll로 모든 접근 허용시킴
- application.yml 추가 : NAVER_SENS 관련 환경변수 추가.
- 네이버 클라우드의 SENS를 이용하여 문자 보내기 구현