### PR TITLE
#31 - 로컬 로그인 단위 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/lifeManager/opalyouth/dto/security/LoginRequest.java
+++ b/src/main/java/com/lifeManager/opalyouth/dto/security/LoginRequest.java
@@ -6,4 +6,11 @@ import lombok.Getter;
 public class LoginRequest { // 로그인 요청 시 Dto
     private String email;
     private String password;
+
+    public LoginRequest() {}
+
+    public LoginRequest(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
 }

--- a/src/main/java/com/lifeManager/opalyouth/utils/JwtUtils.java
+++ b/src/main/java/com/lifeManager/opalyouth/utils/JwtUtils.java
@@ -27,12 +27,6 @@ import static com.lifeManager.opalyouth.common.properties.JwtProperties.REFRESH_
 @Component
 public class JwtUtils {
 
-
-    // todo : jwt secret key 가릴 방법 탐
-//    @Value("${jwt.secret}")
-//    private static String JWT_SECRET;
-
-//    private static final Key JWT_KEY = Keys.hmacShaKeyFor(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
     private final Key key;
 
     public JwtUtils(@Value("${jwt.secret}") String jwtSecret) {

--- a/src/test/java/com/lifeManager/opalyouth/OpalYouthApplicationTests.java
+++ b/src/test/java/com/lifeManager/opalyouth/OpalYouthApplicationTests.java
@@ -3,8 +3,9 @@ package com.lifeManager.opalyouth;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@Disabled
+@ActiveProfiles("test")
 @SpringBootTest
 class OpalYouthApplicationTests {
 

--- a/src/test/java/com/lifeManager/opalyouth/service/security/LoginServiceTest.java
+++ b/src/test/java/com/lifeManager/opalyouth/service/security/LoginServiceTest.java
@@ -1,0 +1,117 @@
+package com.lifeManager.opalyouth.service.security;
+
+import com.lifeManager.opalyouth.common.entity.BaseEntity;
+import com.lifeManager.opalyouth.common.exception.BaseException;
+import com.lifeManager.opalyouth.common.properties.JwtProperties;
+import com.lifeManager.opalyouth.common.response.BaseResponseStatus;
+import com.lifeManager.opalyouth.dto.security.LoginRequest;
+import com.lifeManager.opalyouth.entity.Member;
+import com.lifeManager.opalyouth.repository.MemberRepository;
+import com.lifeManager.opalyouth.utils.JwtUtils;
+import com.lifeManager.opalyouth.utils.OAuth2Utils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class LoginServiceTest {
+    @Mock private HttpServletResponse httpServletResponse;
+    @Mock private MemberRepository memberRepository;
+    @Mock private BCryptPasswordEncoder bCryptPasswordEncoder;
+    @Mock private OAuth2Utils oAuth2Utils;
+    @Mock private JwtUtils jwtUtils;
+    @InjectMocks private LoginService loginService;
+
+    @Test
+    public void givenValidCredentials_whenLocalLogin_thenReturnJwtToken() {
+        // given
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+        Map<String, String> jwtToken = new HashMap<>();
+        jwtToken.put("accessToken", "test_access_token");
+        jwtToken.put("refreshToken", "test_refresh_token");
+
+        String email = "test_email";
+        String password = "test_password";
+        String encodedPwd = encoder.encode(password);
+
+        LoginRequest loginRequest = new LoginRequest(email, password);
+        Member savedMember = Member.builder().email(email).password(encodedPwd).build();
+
+        when(memberRepository.findByEmailAndState(email, BaseEntity.State.ACTIVE))
+                .thenReturn(Optional.ofNullable(savedMember));
+        assert savedMember != null;
+        when(bCryptPasswordEncoder.matches(password, savedMember.getPassword()))
+                .thenReturn(true);
+        when(jwtUtils.generateToken(savedMember)).thenReturn(jwtToken);
+
+        // when
+        String res = loginService.localLogin(loginRequest, httpServletResponse);
+
+        // then
+        assertThat(res).isEqualTo("test_access_token");
+        Mockito.verify(httpServletResponse).addCookie(argThat(cookie ->
+                cookie.getName().equals(JwtProperties.JWT_REFRESH_TOKEN_COOKIE_NAME) &&
+                cookie.getValue().equals("test_refresh_token") &&
+                cookie.getMaxAge() == JwtProperties.REFRESH_TOKEN_EXPIRE_TIME &&
+                cookie.getPath().equals("/")
+        ));
+    }
+
+    @Test
+    public void givenInvalidEmail_whenLocalLogin_thenThrowException() {
+        // given
+        String email = "test_email";
+        String password = "test_password";
+
+        LoginRequest loginRequest = new LoginRequest(email, password);
+
+        when(memberRepository.findByEmailAndState(email, BaseEntity.State.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> loginService.localLogin(loginRequest, httpServletResponse))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(BaseResponseStatus.NON_EXIST_USER.getMessage())
+                .hasFieldOrPropertyWithValue("status", BaseResponseStatus.NON_EXIST_USER);
+    }
+
+    @Test
+    public void givenWrongPassword_whenLocalLogin_thenThrowException() {
+        // given
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+        String email = "test_email";
+        String password = "input_password";
+        String encodedPwd = encoder.encode("saved_password");
+
+        LoginRequest loginRequest = new LoginRequest(email, password);
+        Member savedMember = Member.builder().email(email).password(encodedPwd).build();
+
+        when(memberRepository.findByEmailAndState(email, BaseEntity.State.ACTIVE))
+                .thenReturn(Optional.ofNullable(savedMember));
+        assert savedMember != null;
+        when(bCryptPasswordEncoder.matches(password, savedMember.getPassword()))
+                .thenReturn(false);
+
+        // when, then
+        assertThatThrownBy(() -> loginService.localLogin(loginRequest, httpServletResponse))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(BaseResponseStatus.WRONG_PASSWORD.getMessage())
+                .hasFieldOrPropertyWithValue("status", BaseResponseStatus.WRONG_PASSWORD);
+    }
+}

--- a/src/test/java/com/lifeManager/opalyouth/utils/JwtUtilsTest.java
+++ b/src/test/java/com/lifeManager/opalyouth/utils/JwtUtilsTest.java
@@ -1,0 +1,147 @@
+package com.lifeManager.opalyouth.utils;
+
+import com.lifeManager.opalyouth.common.exception.BaseException;
+import com.lifeManager.opalyouth.common.response.BaseResponseStatus;
+import com.lifeManager.opalyouth.entity.Member;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+@ActiveProfiles("test")
+class JwtUtilsTest {
+    private JwtUtils jwtUtils;
+    private String jwtSecret;
+
+    @BeforeEach
+    void setUp() {
+        jwtSecret = "testJwtSecrettestJwtSecrettestJwtSecrettestJwtSecrettestJwtSecrettestJwtSecrettestJwtSecret";
+        jwtUtils = new JwtUtils(jwtSecret);
+    }
+
+    @Test
+    public void givenMemberEntity_whenGenerateToken_thenReturnToken() {
+        // given
+        Member member = Member.builder().email("test_email").build();
+        member.setId(1L);
+
+        // when
+        Map<String, String> tokens = jwtUtils.generateToken(member);
+
+        // then
+        assertThat(tokens).containsKeys("accessToken", "refreshToken");
+        assertThat(tokens.get("accessToken")).isNotNull();
+        assertThat(tokens.get("refreshToken")).isNotNull();
+    }
+
+    @Test
+    public void givenValidAccessToken_thenShouldContainUserEmailAndId() {
+        // given
+        Member member = Member.builder().email("test_email").build();
+        member.setId(1L);
+        Map<String, String> tokens = jwtUtils.generateToken(member);
+        String accessToken = tokens.get("accessToken");
+
+        // when
+        String extractedUserEmail = jwtUtils.getUserEmail(accessToken);
+        Long extractedUserId = jwtUtils.getUserId(accessToken);
+
+        // then
+        assertThat(extractedUserEmail).isEqualTo(member.getEmail());
+        assertThat(extractedUserId).isEqualTo(member.getId());
+    }
+
+    @Test
+    public void givenExpiredAccessToken_whenGetUserEmail_thenThrowException() {
+        // given
+        Member member = Member.builder().email("test_email").build();
+        member.setId(1L);
+        String expiredAccessToken = Jwts.builder()
+                .setHeaderParam("alg", "HS256")
+                .setHeaderParam("typ", "JWT")
+                .claim("uemail", member.getEmail())
+                .claim("uid", member.getId())
+                .setExpiration(new Date(System.currentTimeMillis()))
+                .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtSecret)), SignatureAlgorithm.HS256)
+                .compact();
+
+        // when, then
+        assertThatThrownBy(() -> jwtUtils.getUserEmail(expiredAccessToken))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(BaseResponseStatus.EXPIRED_JWT_TOKEN.getMessage())
+                .hasFieldOrPropertyWithValue("status", BaseResponseStatus.EXPIRED_JWT_TOKEN);
+    }
+
+    @Test
+    public void givenInvalidAccessToken_whenGetUserEmail_thenThrowException() {
+        // given
+        Member member = Member.builder().email("test_email").build();
+        member.setId(1L);
+        String invalidJwtKey = "invalidJwtKeyinvalidJwtKeyinvalidJwtKeyinvalidJwtKeyinvalidJwtKeyinvalidJwtKeyinvalidJwtKey";
+        String expiredAccessToken = Jwts.builder()
+                .setHeaderParam("alg", "HS256")
+                .setHeaderParam("typ", "JWT")
+                .claim("uemail", member.getEmail())
+                .claim("uid", member.getId())
+                .setExpiration(new Date(System.currentTimeMillis()))
+                .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(invalidJwtKey)), SignatureAlgorithm.HS256)
+                .compact();
+
+        // when, then
+        assertThatThrownBy(() -> jwtUtils.getUserEmail(expiredAccessToken))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(BaseResponseStatus.INVALID_JWT_TOKEN.getMessage())
+                .hasFieldOrPropertyWithValue("status", BaseResponseStatus.INVALID_JWT_TOKEN);
+    }
+
+    @Test
+    public void givenExpiredAccessToken_whenGetUserId_thenThrowException() {
+        // given
+        Member member = Member.builder().email("test_email").build();
+        member.setId(1L);
+        String expiredAccessToken = Jwts.builder()
+                .setHeaderParam("alg", "HS256")
+                .setHeaderParam("typ", "JWT")
+                .claim("uemail", member.getEmail())
+                .claim("uid", member.getId())
+                .setExpiration(new Date(System.currentTimeMillis()))
+                .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtSecret)), SignatureAlgorithm.HS256)
+                .compact();
+
+        // when, then
+        assertThatThrownBy(() -> jwtUtils.getUserId(expiredAccessToken))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(BaseResponseStatus.EXPIRED_JWT_TOKEN.getMessage())
+                .hasFieldOrPropertyWithValue("status", BaseResponseStatus.EXPIRED_JWT_TOKEN);
+    }
+
+    @Test
+    public void givenInvalidAccessToken_whenGetUserId_thenThrowException() {
+        // given
+        Member member = Member.builder().email("test_email").build();
+        member.setId(1L);
+        String invalidJwtKey = "invalidJwtKeyinvalidJwtKeyinvalidJwtKeyinvalidJwtKeyinvalidJwtKeyinvalidJwtKeyinvalidJwtKey";
+        String expiredAccessToken = Jwts.builder()
+                .setHeaderParam("alg", "HS256")
+                .setHeaderParam("typ", "JWT")
+                .claim("uemail", member.getEmail())
+                .claim("uid", member.getId())
+                .setExpiration(new Date(System.currentTimeMillis()))
+                .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(invalidJwtKey)), SignatureAlgorithm.HS256)
+                .compact();
+
+        // when, then
+        assertThatThrownBy(() -> jwtUtils.getUserId(expiredAccessToken))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(BaseResponseStatus.INVALID_JWT_TOKEN.getMessage())
+                .hasFieldOrPropertyWithValue("status", BaseResponseStatus.INVALID_JWT_TOKEN);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    username: sa
+    url: jdbc:h2:mem:test
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: 'true'
+    database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
Jupiter가 아닌 AssertJ를 이용하여 테스트 코드 작성 (AssertJ 사용 이유 : https://xxeol.tistory.com/12)

단위 테스트 코드만 작성. 실제 DB에 저장하는 것과 응답 등을 확인하는 통합 테스트에 대해서는 추후 H2 DB를 이용할 예정 -> Dependecy추가, application-test.yml 작성은 미리 하였음.

### 로컬 로그인 테스트
- Mockito를 이용하여 LoginService.java의 의존성인 MemberRepository, JwtUtils 등에 대해 Mock 객체를 생성해 단위 테스트 작성.
- JwtUtils의 메서드들이 정상적으로 토큰을 발행하는 지는 따로 테스트 수행.

테스트 케이스
- 유효한 인증에 대한 성공 케이스
- 유효하지 않은 이메일(비활성화된 이메일, 존재하지 않는 이메일 등)에 대한 실패 케이스
- 잘못된 비밀번호에 대한 실패 케이스
<img width="662" alt="Screenshot 2024-07-15 at 3 06 11 PM" src="https://github.com/user-attachments/assets/345e84a8-27de-4dc6-9dfd-165d11d8be02">

### Jwt 토큰 발행 테스트
테스트 케이스
- 유효한 Member entity에 대한 정상적인 토큰 반환 성공 케이스
- 유효한 Jwt token으로 부터 User Email, Id 추출 성공 케이스
- 만료된 토큰으로부터 Email, Id 추출 시 실패 케이스
- 비정상적인 토큰으로부터 Email, Id 추출 시 실패 케이스
<img width="667" alt="Screenshot 2024-07-15 at 3 05 42 PM" src="https://github.com/user-attachments/assets/c18bda49-19c2-4d20-8698-ba7fafc934ed">
