### PR TITLE
#32 - 프로필 수정 테스트 코드

### DIFF
--- a/src/test/java/com/lifeManager/opalyouth/updateProfileTest/UpdateProfileTest.java
+++ b/src/test/java/com/lifeManager/opalyouth/updateProfileTest/UpdateProfileTest.java
@@ -1,0 +1,124 @@
+package com.lifeManager.opalyouth.updateProfileTest;
+
+import com.lifeManager.opalyouth.common.entity.BaseEntity;
+import com.lifeManager.opalyouth.common.exception.BaseException;
+import com.lifeManager.opalyouth.common.response.BaseResponseStatus;
+import com.lifeManager.opalyouth.dto.member.request.MemberProfileInfoRequest;
+import com.lifeManager.opalyouth.entity.Details;
+import com.lifeManager.opalyouth.entity.Member;
+import com.lifeManager.opalyouth.repository.MemberRepository;
+import com.lifeManager.opalyouth.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateProfileTest {
+    @Mock private MemberRepository memberRepository;
+    @InjectMocks private MemberService memberService;
+
+    private final String TESTER_EMAIL = "test@test.com";
+    private Member savedMember;
+    private MemberProfileInfoRequest req;
+
+    @BeforeEach
+    void setUp() {
+        savedMember = Member.builder().job("job").introduction("intro").build();
+        Details details = Details.builder()
+                .maritalStatus(Details.MaritalStatus.SINGLE)
+                .hasChildren(false)
+                .personality("personality")
+                .hobby("hobby")
+                .build();
+        savedMember.setDetails(details);
+        req = createMemberProfileInfoRequest(
+                "changed job",
+                "ichanged ntroduction",
+                "MARRIED",
+                true,
+                "persionallity",
+                "hobby");
+    }
+
+    @Test
+    @DisplayName("정상적인 요청 시 업데이트 성공")
+    public void givenValidRequest_whenUpdateProfile_thenUpdate() {
+        // given
+        Principal principal = () -> TESTER_EMAIL;
+        Mockito.when(memberRepository.findByEmailAndState(TESTER_EMAIL, BaseEntity.State.ACTIVE))
+                .thenReturn(Optional.of(savedMember));
+
+        // when
+        memberService.updateProfile(principal, req);
+
+        // then
+        Mockito.verify(memberRepository).save(savedMember);
+        assertThat(savedMember.getJob()).isEqualTo(req.getJob());
+        assertThat(savedMember.getIntroduction()).isEqualTo(req.getIntroduction());
+        assertThat(savedMember.getDetails().getMaritalStatus().toString()).isEqualTo(req.getMaritalStatus());
+        assertThat(savedMember.getDetails().isHasChildren()).isEqualTo(req.isHasChildren());
+        assertThat(savedMember.getDetails().getPersonality()).isEqualTo(req.getPersonality());
+        assertThat(savedMember.getDetails().getHobby()).isEqualTo(req.getHobby());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 이메일로 요청 시 발생")
+    public void givenInvalidEmail_whenUpdateProfile_thenThrowException() {
+        // given
+        Principal principal = () -> TESTER_EMAIL;
+        Mockito.when(memberRepository.findByEmailAndState(TESTER_EMAIL, BaseEntity.State.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> memberService.updateProfile(principal, req))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(BaseResponseStatus.NON_EXIST_USER.getMessage())
+                .hasFieldOrPropertyWithValue("status", BaseResponseStatus.NON_EXIST_USER);
+    }
+
+    @Test
+    @DisplayName("데이터 베이스 삽입할 경우 에러 발생 시 예외 발생")
+    public void givenValidRequest_whenOccurDBError_thenThrowException() {
+        // given
+        Principal principal = () -> TESTER_EMAIL;
+        Mockito.when(memberRepository.findByEmailAndState(TESTER_EMAIL, BaseEntity.State.ACTIVE))
+                .thenReturn(Optional.of(savedMember));
+
+        // when
+        Mockito.when(memberRepository.save(any(Member.class)))
+                .thenThrow(new RuntimeException());
+
+        // then
+        assertThatThrownBy(() -> memberService.updateProfile(principal, req))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(BaseResponseStatus.DATABASE_INSERT_ERROR.getMessage())
+                .hasFieldOrPropertyWithValue("status", BaseResponseStatus.DATABASE_INSERT_ERROR);
+    }
+
+    MemberProfileInfoRequest createMemberProfileInfoRequest(String job,
+                                                            String introduction,
+                                                            String maritalStatus,
+                                                            boolean hasChildren,
+                                                            String personallity,
+                                                            String hobby) {
+        MemberProfileInfoRequest req = new MemberProfileInfoRequest();
+        req.setJob(job);
+        req.setIntroduction(introduction);
+        req.setMaritalStatus(maritalStatus);
+        req.setHasChildren(hasChildren);
+        req.setPersonality(personallity);
+        req.setHobby(hobby);
+        return req;
+    }
+}


### PR DESCRIPTION
### MemberService의 프로필 수정 메서드에 대한 단위 테스트.

Principle 인터페이스의 getName()만 구현하여 사용자의 이메일은 정상적으로 반환한다고 가정.
Controller의 파라미터로 들어오는 MemberProfileInfoRequest 객체가 정상적으로 들어온다고 가정

1. givenValidRequest_whenUpdateProfile_thenUpdate() : 정상적인 요청이 들어왔을 때, memberRepository에 수정된 entity가 save되었는지 확인. saveMember객체가 request로 들어온 변경된 값으로 성공적으로 변환되었는지 확인.

2. givenInvalidEmail_whenUpdateProfile_thenThrowException() : 사용자의 이메일이 유효하지 않아 MemberRepository 조회 시 Null이 반환된 경우, 던지는 예외 확인.

3. givenValidRequest_whenOccurDBError_thenThrowException() : MemberRepository에 데이터 삽입 시 RuntimeException을 발생시켜 데이터 삽입하는 경우에 대한 예외처리 테스트.
----
<img width="574" alt="Screenshot 2024-07-23 at 6 43 42 PM" src="https://github.com/user-attachments/assets/4577c352-3b0a-410c-aa70-c20b5abe4f38">
